### PR TITLE
Instantiate everything in the "dependencies"

### DIFF
--- a/0-Dependencies.ipynb
+++ b/0-Dependencies.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "727707be",
+   "metadata": {},
+   "source": [
+    "To get started, we need to install package. `Pkg` is Julia's package manager:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "76a9cd36-c3a7-42e3-b10a-9041439b608c",
@@ -10,6 +18,14 @@
    "outputs": [],
    "source": [
     "using Pkg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2eb16487",
+   "metadata": {},
+   "source": [
+    "We've created a special *environment* with everything you'll need. Let's activate it:"
    ]
   },
   {
@@ -33,13 +49,13 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f7a52ba4-2cb2-40e7-94f0-78b7cd4033eb",
+   "cell_type": "markdown",
+   "id": "611b1b99",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "Pkg.add(\"FileIO\")"
+    "This assumes that the current directory is your local checkout of the [GitHub repository](https://github.com/JuliaImages/JuliaCon23_ImageProcessingWorkshop).\n",
+    "\n",
+    "You can add packages manually:"
    ]
   },
   {
@@ -63,6 +79,14 @@
    ],
    "source": [
     "Pkg.add(\"FileIO\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66320e5d",
+   "metadata": {},
+   "source": [
+    "But to install everything you'll need for this workshop, just *instantiate* the whole environment:"
    ]
   },
   {
@@ -191,7 +215,7 @@
     }
    ],
    "source": [
-    "Pkg.add(\"Plots\")"
+    "Pkg.instantiate()"
    ]
   },
   {


### PR DESCRIPTION
I was finding that having `Pkg.add("Images")` in the Introduction was adding a lot of unnecessary latency when I re-ran the notebook, so I propose get all unnecessary `Pkg` operation out of the individual notebooks.